### PR TITLE
Add libgbm-dev dependency

### DIFF
--- a/node12-electron-chrome/Dockerfile
+++ b/node12-electron-chrome/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     default-jre \
 #    winehq-stable \
     libgconf-2-4 \
+    libgbm-dev \
     --no-install-recommends
 
 # Get Chrome sources


### PR DESCRIPTION
Fixes electron is not able to start.

```
Cannot start Electron /builds/metabo/metabot/node_modules/electron/dist/electron: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory

Electron stderr: /builds/metabo/metabot/node_modules/electron/dist/electron: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```